### PR TITLE
docs: cite published OreoLook paper

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,4 +1,4 @@
-cff-version: 2.2.0
+cff-version: 1.2.0
 type: software
 title: "A Three-Layer Caching Architecture for Low-Latency LLM Web Search on Commodity CPU Hardware"
 abstract: "A production-grade, horizontally-scalable search and Retrieval-Augmented Generation (RAG) system featuring multi-layer caching, Playwright-based search agents, and Huffman-compressed session archival on commodity CPU hardware."
@@ -8,16 +8,29 @@ authors:
     given-names: "Ayushman"
     email: "ayushman@myceli.ai"
     affiliation: "Pollinations.ai"
+  - family-names: "Gazi"
+    given-names: "Nihal"
+    email: "info@nihalgazi.com"
+    affiliation: "Pollinations.ai"
 
 contact:
   - family-names: "Bhattacharya"
     given-names: "Ayushman"
     email: "ayushman@myceli.ai"
 
-date-released: 2026-02-25
+date-released: 2026-08-12
 identifiers:
+  - type: "doi"
+    value: "10.48550/arXiv.2609.05463"
   - type: "url"
-    value: "https://github.com/pollinations/lixsearch"
+    value: "https://arxiv.org/abs/2609.05463"
+    description: "Published paper on arXiv"
+  - type: "url"
+    value: "https://huggingface.co/papers/2609.05463"
+    description: "Paper page on Hugging Face"
+  - type: "url"
+    value: "https://github.com/pollinations/search.elixpo"
+    description: "Source code repository"
 
 keywords:
   - "search"
@@ -36,7 +49,7 @@ keywords:
 license: "MIT"
 license-url: "https://opensource.org/licenses/MIT"
 
-repository-code: "https://github.com/pollinations/lixsearch"
+repository-code: "https://github.com/pollinations/search.elixpo"
 url: "https://search.elixpo.com"
 
 version: "1.0.0"
@@ -49,8 +62,13 @@ preferred-citation:
       given-names: "Ayushman"
       email: "ayushman@myceli.ai"
       affiliation: "Pollinations.ai"
+    - family-names: "Gazi"
+      given-names: "Nihal"
+      email: "info@nihalgazi.com"
+      affiliation: "Pollinations.ai"
   year: 2026
-  url: "https://github.com/pollinations/lixsearch/blob/main/docs/paper/lix_cache_paper.pdf"
+  doi: "10.48550/arXiv.2609.05463"
+  url: "https://arxiv.org/abs/2609.05463"
   license: "CC-BY-NC-ND-4.0"
   abstract: "We present a three-layer caching architecture for scaling LLM-powered web search on commodity CPU hardware. Deployed on a single 8-vCPU server, the system achieves an 89.3% cache hit rate with 0.1ms Redis read latency, reducing per-query cost by 1,000x compared to commercial search APIs."
 


### PR DESCRIPTION
## Published paper metadata
- adds Nihal Gazi as co-author
- links arXiv:2609.05463 and its DOI
- links the Hugging Face paper page
- corrects the source repository URL
- records the August 12, 2026 publication date
- corrects the Citation File Format schema version to 1.2.0

Publication: https://arxiv.org/abs/2609.05463

Validated by parsing CITATION.cff and asserting the preferred DOI and both author records.