### PR TITLE
feat(memory): add clarification state machine

### DIFF
--- a/lixsearch/commons/requestID.py
+++ b/lixsearch/commons/requestID.py
@@ -7,11 +7,18 @@ def reqID():
     return str(uuid.uuid4())[:REQUEST_ID_LEGACY_SLICE_SIZE]
 
 
+def _request_log_target(request) -> str:
+    """Return a useful request target without ever logging query values."""
+    return request.url.path
+
+
 class RequestIDMiddleware(BaseHTTPMiddleware):
     async def dispatch(self, request, call_next):
         request_id = reqID()
         request.state.request_id = request_id
-        logger.info(f"Request {request_id} started: {request.method} {request.url}")
+        logger.info(
+            f"Request {request_id} started: {request.method} {_request_log_target(request)}"
+        )
         response = await call_next(request)
         response.headers["X-Request-ID"] = request_id
         logger.info(f"Request {request_id} finished")

--- a/lixsearch/pipeline/deep_search.py
+++ b/lixsearch/pipeline/deep_search.py
@@ -19,6 +19,7 @@ from pipeline.instruction import (
 )
 from pipeline.tools import tools
 from pipeline.optimized_tool_execution import optimized_tool_execution
+from pipeline.response_builder import auto_generate_pdf
 from pipeline.helpers import (
     _scrub_tool_names,
     _decompose_query_with_llm,
@@ -237,6 +238,23 @@ async def _execute_deep_search_sub_query(
         tool_calls = assistant_message.get("tool_calls")
 
         if not tool_calls:
+            # Deep research is not allowed to manufacture an answer from model
+            # memory. Give the model bounded chances to gather web evidence;
+            # the caller applies a second commit gate before any text reaches
+            # SSE, caches, or an artifact.
+            if not collected_sources and iteration < DEEP_SEARCH_MAX_ITERATIONS_PER_SUB:
+                messages.append({
+                    "role": "user",
+                    "content": (
+                        "No verifiable web evidence has been collected yet. Use the available "
+                        "search and fetch tools now. Do not answer from memory or invent sources."
+                    ),
+                })
+                logger.warning(
+                    f"[DeepSearch:Sub{sub_query_index}] Iteration {iteration}: "
+                    "source-free answer rejected; requesting evidence"
+                )
+                continue
             final_content = assistant_message.get("content")
             logger.info(f"[DeepSearch:Sub{sub_query_index}] Iteration {iteration}: no tool calls, final content ready ({len(final_content or '')} chars)")
             break
@@ -474,6 +492,7 @@ async def _run_deep_search_pipeline(
     session_id: str,
     emit_event,
     ledger_request_id: str = None,
+    request_intent: str = None,
 ):
     logger.info(f"[DeepSearch] Starting deep search for: '{user_query[:80]}'")
     ledger_request_id = ledger_request_id or event_id or uuid.uuid4().hex
@@ -605,7 +624,16 @@ async def _run_deep_search_pipeline(
                 sq_response = _scrub_tool_names(sq_response)
                 # Strip reasoning leaks: remove everything before the first markdown heading or real content
                 sq_response = _strip_reasoning_leak(sq_response)
-            return sq_idx, sub_query, sq_response, sq_sources, sq_images
+            evidence_sources = list(dict.fromkeys(
+                source for source in (sq_sources or []) if _is_clean_url(source)
+            ))
+            if sq_response and not evidence_sources:
+                logger.warning(
+                    f"[DeepSearch] Sub-query {sq_idx} rejected by evidence commit gate: "
+                    "no clean sources"
+                )
+                sq_response = None
+            return sq_idx, sub_query, sq_response, evidence_sources, sq_images
         except asyncio.TimeoutError:
             logger.error(f"[DeepSearch] Sub-query {sq_idx} timed out after {DEEP_SEARCH_TIMEOUT_PER_SUB}s")
             return sq_idx, sub_query, None, [], []
@@ -649,6 +677,21 @@ async def _run_deep_search_pipeline(
             )
             if timeout_event:
                 yield timeout_event
+
+    if not all_sub_results:
+        failure = (
+            "I couldn’t gather enough verifiable sources to answer this reliably. "
+            "Please try again in a moment."
+        )
+        if event_id:
+            yield format_sse("RESPONSE", failure)
+        else:
+            yield failure
+        done_event = emit_event("INFO", "<TASK>DONE</TASK>")
+        if done_event:
+            yield done_event
+        logger.warning("[DeepSearch] Aborted: no source-backed research passed the commit gate")
+        return
 
     # ── Clean sources: filter out ad tracking / redirect URLs ──
     unique_sources = sorted(set(s for s in all_collected_sources if _is_clean_url(s)))[:8]
@@ -694,8 +737,31 @@ async def _run_deep_search_pipeline(
             except Exception as e:
                 logger.error(f"[DeepSearch] Final synthesis failed: {e}", exc_info=True)
 
-    # ── Save to caches (fire-and-forget, never block DONE) ──
+    # Complete any requested artifact from the researched content before DONE.
+    # The shared finalizer determines whether this request asks for an export;
+    # this path does not special-case a subject, field name, or prompt shape.
     combined_content = "\n\n".join(r[1] for r in all_sub_results) if all_sub_results else None
+    if combined_content:
+        try:
+            pdf_url = await auto_generate_pdf(
+                combined_content,
+                request_intent or user_query,
+                memoized_results,
+                event_id,
+            )
+            if pdf_url:
+                ready_event = emit_event("INFO", "<TASK>PDF ready for download</TASK>")
+                if ready_event:
+                    yield ready_event
+                link = f"\n\n---\n\n[Download PDF]({pdf_url})"
+                if event_id:
+                    yield format_sse("RESPONSE", link)
+                else:
+                    yield link
+        except Exception as e:
+            logger.error(f"[DeepSearch] PDF auto-generation failed: {e}")
+
+    # ── Save to caches (fire-and-forget, never block DONE) ──
     try:
         if combined_content:
             memoized_results["final_response"] = combined_content

--- a/lixsearch/pipeline/instruction.py
+++ b/lixsearch/pipeline/instruction.py
@@ -101,7 +101,7 @@ CRITICAL RULES:
 
 LENGTH: {length_guide}
 
-FORMAT: Markdown. Start with the answer. Cite as [Title](URL). Never mention tools, cache, RAG, or internal processes.
+FORMAT: Markdown. Start with the answer. Cite as [Title](URL). Never mention tools, cache, RAG, or internal processes. Never claim that a listed capability is unavailable; perform it, or report only a real runtime failure after it occurs.
 
 CONTEXT:
 {rag_context}

--- a/lixsearch/pipeline/lixsearch.py
+++ b/lixsearch/pipeline/lixsearch.py
@@ -7,6 +7,19 @@ import json
 import re
 from pipeline.tools import tools
 from sessions.conversation_cache import ConversationCacheManager
+from sessions.clarification import (
+    ClarificationNeed,
+    ResolutionAction,
+    TaskStatus,
+    apply_resolution,
+    create_pending_task,
+    has_decision_contract,
+    has_resolution_contract,
+    parse_clarification_need,
+    parse_resolution,
+    pending_for_request,
+    task_with_status,
+)
 from sessions.ledger import LedgerSessionContext
 
 import os
@@ -57,13 +70,25 @@ MODEL = LLM_MODEL
 MODEL_FALLBACK = LLM_MODEL_FALLBACK
 
 
-_DECISION_INSTRUCTION = """Classify tool need and conversation dependence for this request.
-Return only JSON: {"mode":"DIRECT|TOOLS","context":"STANDALONE|CONTINUATION"}.
-TOOLS: live/current facts, search, URL reading, time zones, images, audio, YouTube, PDF export, or multi-step research.
+_DECISION_INSTRUCTION = """Classify tool need, conversation dependence, and absent inputs. Never answer the request.
+Return only JSON: {"mode":"DIRECT|TOOLS","context":"STANDALONE|CONTINUATION","clarification":{"required":false,"blocking_fields":[],"defaultable_fields":[],"questions":{}}}.
+Use exact snake_case field names. Put only indispensable inputs in blocking_fields. Put optional preferences and output metadata in defaultable_fields. For every blocking field, questions must contain one concise question under the identical key.
+TOOLS: live/current facts, search, URL reading, time zones, images, audio, YouTube, artifact creation, or multi-step research.
 DIRECT: greetings, casual conversation, opinions, explanations, writing, coding, math, and stable knowledge.
-CONTINUATION: the request cannot be interpreted correctly without earlier turns, such as explicit references to "that", "it", "the previous answer", continuing prior work, recaps, or exporting existing conversation content.
-STANDALONE: the request states a complete subject and desired output. Repeated or reformulated complete requests remain STANDALONE even when a session exists. "Give me a PDF of the latest news from India" is STANDALONE because it requests new live research, not prior content.
-Attached images require TOOLS. Never answer the request."""
+CONTINUATION: the request cannot be interpreted correctly without earlier turns because it refers to earlier content or continues earlier work.
+STANDALONE: the request states a complete subject and desired output. A new result remains standalone even when its output is an artifact; transforming an earlier result is a continuation.
+Identity, user-owned values, credentials, authorization decisions, irreversible choices, and genuinely required scope are blocking. Preferences and output metadata are always safely defaultable and never block execution. Output names, titles, styling, layout, verbosity, and presentation belong in defaultable_fields unless the user explicitly made a particular value mandatory. A count, category, pronoun, generic label, or placeholder is not an identity. A referent supplied by conversation context is not absent. Set required=true exactly when blocking_fields is non-empty. Defaultable fields must never appear in questions. The runtime ignores defaultable_fields when constructing clarification state.
+Attached images require TOOLS."""
+
+
+_RESOLUTION_INSTRUCTION = """Resolve a reply against one pending clarification task.
+Return only JSON: {"action":"resolve|partial|unrelated|cancel|replace","values":{},"defaulted_fields":[],"question":"","replacement_request":""}.
+resolve: the reply plus the original request makes the task executable. Put explicitly supplied information under exact missing-field keys in values. Put any remaining nonessential fields that have safe, reversible, context-appropriate defaults in defaulted_fields.
+partial: indispensable information is still absent; include supplied values, any safely defaulted fields, and one concise question covering only what remains indispensable.
+unrelated: it does not answer or complete the pending task; keep values and defaulted_fields empty and repeat or improve the concise question.
+cancel: it clearly cancels the pending task.
+replace: it clearly requests a different task; put that complete new request in replacement_request.
+Never default an identity, secret, user-owned value, authorization decision, or irreversible choice. Never invent supplied values, never treat an unrelated reply as an answer, and never execute the task."""
 
 
 def _parse_decision_mode(content: str) -> str:
@@ -76,39 +101,171 @@ def _parse_context_mode(content: str) -> str:
     return match.group(1).lower() if match else "standalone"
 
 
-async def _decide_request_mode(user_query: str, image_count: int, headers: dict) -> tuple[str, str]:
-    """Run the cheap routing decision while local context is prepared."""
+def _may_stream_uncommitted_output(
+    event_id: str | None,
+    *,
+    has_tools: bool,
+    artifact_requested: bool,
+) -> bool:
+    """Allow progressive output only when no validation/export commit is pending."""
+    return bool(event_id) and not has_tools and not artifact_requested
+
+
+async def _decide_request_mode(
+    user_query: str,
+    image_count: int,
+    headers: dict,
+    context_excerpt: str = "",
+) -> tuple[str, str, object]:
+    """Return the first valid decision from redundant bounded routers."""
     query = user_query or "(no text)"
     if image_count:
         query += f"\n[Attached images: {image_count}]"
-    payload = {
-        "model": LLM_DECISION_MODEL,
-        "messages": [
-            {"role": "system", "content": _DECISION_INSTRUCTION},
-            {"role": "user", "content": query},
-        ],
-        "max_tokens": 30,
-        "temperature": 0,
-    }
+    if context_excerpt:
+        query += f"\n[Available conversation context]\n{context_excerpt[:1200]}"
 
-    def _call():
+    messages = [
+        {"role": "system", "content": _DECISION_INSTRUCTION},
+        {"role": "user", "content": query},
+    ]
+    models = list(dict.fromkeys((LLM_DECISION_MODEL, LLM_MODEL_FALLBACK)))
+
+    def _call(model):
         response = requests.post(
-            POLLINATIONS_ENDPOINT, json=payload, headers=headers,
-            timeout=LLM_DECISION_TIMEOUT_SECONDS,
+            POLLINATIONS_ENDPOINT,
+            json={
+                "model": model,
+                "messages": messages,
+                "max_tokens": 260,
+                "temperature": 0,
+            },
+            headers=headers,
+            timeout=max(LLM_DECISION_TIMEOUT_SECONDS, 5.0),
         )
         response.raise_for_status()
-        message = response.json()["choices"][0]["message"]
-        content = message.get("content", "")
-        return _parse_decision_mode(content), _parse_context_mode(content)
+        content = response.json()["choices"][0]["message"].get("content", "")
+        if not has_decision_contract(content):
+            raise ValueError(f"router model {model} returned an invalid contract")
+        return (
+            _parse_decision_mode(content),
+            _parse_context_mode(content),
+            parse_clarification_need(content),
+        )
 
+    tasks = [asyncio.create_task(asyncio.to_thread(_call, model)) for model in models]
     try:
-        mode, context_mode = await asyncio.to_thread(_call)
-        logger.debug(f"[pipeline] request_mode={mode} context_mode={context_mode}")
-        return mode, context_mode
-    except Exception as exc:
-        logger.debug(f"[pipeline] decision fallback=tools/standalone error={exc}")
-        return "tools", "standalone"
+        for completed in asyncio.as_completed(tasks):
+            try:
+                mode, context_mode, clarification = await completed
+                for task in tasks:
+                    if not task.done():
+                        task.cancel()
+                logger.debug(
+                    f"[pipeline] request_mode={mode} context_mode={context_mode}"
+                )
+                logger.info(
+                    "[clarification] route required={} blocking_fields={}",
+                    clarification.required,
+                    list(clarification.missing_fields),
+                )
+                return mode, context_mode, clarification
+            except Exception as exc:
+                logger.warning(f"[pipeline] request router attempt failed: {exc}")
+    finally:
+        for task in tasks:
+            if not task.done():
+                task.cancel()
 
+    # Routing is an admission boundary. If every bounded router fails, do not
+    # let the more permissive tool orchestrator guess at an underspecified
+    # request. Persist one generic, resolvable field so the next turn can
+    # continue the original task in the same session.
+    logger.error("[pipeline] every request router failed; requesting safe clarification")
+    return (
+        "tools",
+        "standalone",
+        ClarificationNeed(
+            required=True,
+            missing_fields=("request_details",),
+            question="What specific subject or inputs should I use for this request?",
+        ),
+    )
+
+
+async def _resolve_pending_clarification(
+    active_task: dict,
+    pending: dict,
+    user_reply: str,
+    headers: dict,
+):
+    base_messages = [
+        {"role": "system", "content": _RESOLUTION_INSTRUCTION},
+        {
+            "role": "user",
+            "content": json.dumps(
+                {
+                    "active_task": active_task,
+                    "pending_clarification": pending,
+                    "reply": user_reply,
+                },
+                ensure_ascii=False,
+            ),
+        },
+    ]
+    models = list(dict.fromkeys((LLM_DECISION_MODEL, LLM_MODEL_FALLBACK)))
+
+    def _call(model):
+        response = requests.post(
+            POLLINATIONS_ENDPOINT,
+            json={
+                "model": model,
+                "messages": base_messages,
+                "max_tokens": 220,
+                "temperature": 0,
+            },
+            headers=headers,
+            timeout=max(LLM_DECISION_TIMEOUT_SECONDS, 5.0),
+        )
+        response.raise_for_status()
+        content = response.json()["choices"][0]["message"].get("content", "")
+        if not has_resolution_contract(content):
+            raise ValueError(f"resolver model {model} returned an invalid contract")
+        return parse_resolution(content)
+
+    tasks = [asyncio.create_task(asyncio.to_thread(_call, model)) for model in models]
+    try:
+        for completed in asyncio.as_completed(tasks):
+            try:
+                resolution = await completed
+                for task in tasks:
+                    if not task.done():
+                        task.cancel()
+                return resolution
+            except Exception as exc:
+                logger.warning(f"[pipeline] clarification resolver attempt failed: {exc}")
+    finally:
+        for task in tasks:
+            if not task.done():
+                task.cancel()
+
+    # The admission fallback creates exactly one generic field. Its answer is
+    # the user's next explicit message, so it can be bound without semantic
+    # guessing when resolver models are unavailable. All model-declared fields
+    # remain fail-closed.
+    missing_fields = tuple(pending.get("missing_fields") or ())
+    reply = (user_reply or "").strip()
+    if missing_fields == ("request_details",) and reply:
+        logger.warning("[pipeline] resolver unavailable; binding generic request details")
+        return parse_resolution(json.dumps({
+            "action": "resolve",
+            "values": {"request_details": reply},
+            "defaulted_fields": [],
+            "question": "",
+            "replacement_request": "",
+        }))
+
+    logger.warning("[pipeline] every clarification resolver failed safely")
+    return parse_resolution("")
 
 async def _stream_llm_call(payload: dict, headers: dict):
     """Stream an LLM call from Pollinations. Yields ("content", str) for text
@@ -242,15 +399,12 @@ async def run_elixposearch_pipeline(user_query: str, user_image: str, event_id: 
     session_context = None
     session_lock_token = None
     ledger_request_id = event_id or uuid.uuid4().hex
+    task_failed = False
 
     try:
         current_utc_time = datetime.now(timezone.utc)
         headers = {"Content-Type": "application/json",
                    "Authorization": f"Bearer {POLLINATIONS_API_KEY}"}
-        decision_task = asyncio.create_task(
-            _decide_request_mode(original_user_query, len(user_images), headers)
-        )
-
         try:
             from ipcService.coreServiceManager import get_core_embedding_service
             core_service = get_core_embedding_service()
@@ -266,6 +420,8 @@ async def run_elixposearch_pipeline(user_query: str, user_image: str, event_id: 
 
         # --- Session context (skip for ephemeral — no history to load or persist) ---
         previous_messages = []
+        snapshot = None
+        source_turn = 0
         if session_id and not is_ephemeral:
             try:
                 session_context = LedgerSessionContext(session_id=session_id)
@@ -277,7 +433,7 @@ async def run_elixposearch_pipeline(user_query: str, user_image: str, event_id: 
                 previous_messages = snapshot.messages
                 memoized_results["session_snapshot"] = snapshot
                 memoized_results["ledger_request_id"] = ledger_request_id
-                session_context.add_message(
+                source_turn = session_context.add_message(
                     role="user",
                     content=user_query,
                     metadata={"request_id": f"{ledger_request_id}:user"},
@@ -293,6 +449,97 @@ async def run_elixposearch_pipeline(user_query: str, user_image: str, event_id: 
                 session_context = None
                 logger.error(f"[Pipeline] Session ledger unavailable: {exc}")
                 raise
+
+        resolved_pending_task = False
+
+        # Pending clarification is resolved before general routing. Only the
+        # same durable session can load and consume this state.
+        request_pending = pending_for_request(snapshot, session_id, is_ephemeral)
+        if request_pending:
+            memoized_results["active_task"] = snapshot.active_task or {}
+            memoized_results["pending_clarification"] = request_pending
+            memoized_results["suppress_pdf_export"] = True
+            resolution = await _resolve_pending_clarification(
+                snapshot.active_task or {},
+                snapshot.pending_clarification,
+                user_query,
+                headers,
+            )
+            logger.info(
+                "[clarification] resolution action={} supplied_fields={} defaulted_fields={}",
+                resolution.action.value,
+                sorted(resolution.values),
+                list(resolution.defaulted_fields),
+            )
+            next_task, next_pending, executable_request = apply_resolution(
+                snapshot.active_task or {},
+                snapshot.pending_clarification,
+                resolution,
+            )
+            await asyncio.to_thread(
+                session_context.ledger.set_task_state,
+                active_task=next_task or None,
+                pending_clarification=next_pending,
+            )
+            memoized_results["active_task"] = next_task
+            memoized_results["pending_clarification"] = next_pending
+
+            if resolution.action == ResolutionAction.CANCEL:
+                reply = "Got it — I’ve cancelled that request."
+                memoized_results["final_response"] = reply
+                memoized_results["task_terminal"] = True
+                if event_id:
+                    yield format_sse("RESPONSE", reply)
+                    yield format_sse("INFO", "<TASK>DONE</TASK>")
+                else:
+                    yield reply
+                return
+
+            if resolution.action == ResolutionAction.REPLACE and executable_request:
+                user_query = executable_request
+                original_user_query = executable_request
+                memoized_results["suppress_pdf_export"] = False
+            elif executable_request:
+                user_query = executable_request
+                original_user_query = executable_request
+                memoized_results["suppress_pdf_export"] = False
+                resolved_pending_task = True
+            else:
+                question = (
+                    (next_pending or {}).get("question")
+                    or request_pending.get("question")
+                    or "Could you clarify the missing information?"
+                )
+                memoized_results["final_response"] = question
+                memoized_results["clarification_blocked"] = True
+                if event_id:
+                    yield format_sse("RESPONSE", question)
+                    yield format_sse("INFO", "<TASK>DONE</TASK>")
+                else:
+                    yield question
+                return
+
+        context_messages = chat_history if chat_history is not None else previous_messages
+        context_excerpt = "\n".join(
+            f"{message.get('role', 'user')}: {message.get('content', '')[:300]}"
+            for message in (context_messages or [])[-4:]
+            if message.get("content")
+        )
+        decision_task = None
+        if resolved_pending_task:
+            stored_routing = (memoized_results.get("active_task") or {}).get("routing") or {}
+            request_mode = stored_routing.get("mode") or "tools"
+            context_mode = "standalone"
+            clarification = ClarificationNeed()
+        else:
+            decision_task = asyncio.create_task(
+                _decide_request_mode(
+                    original_user_query,
+                    len(user_images),
+                    headers,
+                    context_excerpt=context_excerpt,
+                )
+            )
 
         # --- Conversation cache + Semantic cache (skip for ephemeral — no history) ---
         conversation_cache = None
@@ -316,6 +563,57 @@ async def run_elixposearch_pipeline(user_query: str, user_image: str, event_id: 
                 redis_db=SEMANTIC_CACHE_REDIS_DB
             )
             semantic_cache.load_for_request(session_id)
+
+        if decision_task is not None:
+            request_mode, context_mode, clarification = await decision_task
+
+        if clarification.required:
+            memoized_results["suppress_pdf_export"] = True
+            memoized_results["clarification_blocked"] = True
+            if session_context:
+                active_task, pending = create_pending_task(
+                    original_user_query,
+                    clarification.missing_fields,
+                    clarification.question,
+                    source_turn=source_turn,
+                    request_id=ledger_request_id,
+                    routing={"mode": request_mode, "context": context_mode},
+                )
+                await asyncio.to_thread(
+                    session_context.ledger.set_task_state,
+                    active_task=active_task,
+                    pending_clarification=pending,
+                )
+                memoized_results["active_task"] = active_task
+                memoized_results["pending_clarification"] = pending
+            memoized_results["final_response"] = clarification.question
+            if event_id:
+                yield format_sse("RESPONSE", clarification.question)
+                yield format_sse("INFO", "<TASK>DONE</TASK>")
+            else:
+                yield clarification.question
+            return
+
+        if session_context:
+            current_task = memoized_results.get("active_task") or {}
+            if current_task.get("status") == TaskStatus.READY_TO_EXECUTE.value:
+                active_task = task_with_status(current_task, TaskStatus.ACTIVE)
+            else:
+                active_task = task_with_status(
+                    {
+                        "original_request": original_user_query,
+                        "source_turn": source_turn,
+                        "request_id": ledger_request_id,
+                    },
+                    TaskStatus.ACTIVE,
+                )
+            await asyncio.to_thread(
+                session_context.ledger.set_task_state,
+                active_task=active_task,
+                pending_clarification=None,
+            )
+            memoized_results["active_task"] = active_task
+            memoized_results["pending_clarification"] = None
 
         # --- Image handling ---
         image_context_provided = False
@@ -430,8 +728,6 @@ async def run_elixposearch_pipeline(user_query: str, user_image: str, event_id: 
             current_utc_time, session_id=session_id, interaction_signals=interaction_signals,
             global_revelations=global_revelations, rag_context="",
         )
-
-        request_mode, context_mode = await decision_task
 
         # Explicit OpenAI messages history is authoritative. Server-loaded
         # session history enters only genuine continuation requests.
@@ -574,7 +870,13 @@ async def run_elixposearch_pipeline(user_query: str, user_image: str, event_id: 
             # synthesis has no tools and remains progressively streamed.
             _pdf_requested = any(kw in original_user_query.lower() for kw in ("pdf", "export", "save as", "document", "download"))
             # Buffer PDF synthesis until document structure and coverage validate.
-            _use_streaming = bool(event_id) and not payload.get("tools") and not (force_synthesis and _pdf_requested)
+            # Artifact drafts are buffered until synthesis, validation, and export
+            # complete; uncommitted model text must never leak to the client.
+            _use_streaming = _may_stream_uncommitted_output(
+                event_id,
+                has_tools=bool(payload.get("tools")),
+                artifact_requested=_pdf_requested,
+            )
             _streamed_content = ""
 
             if _use_streaming:
@@ -751,6 +1053,22 @@ async def run_elixposearch_pipeline(user_query: str, user_image: str, event_id: 
                         assistant_message["tool_calls"] = tool_calls
 
                 if not tool_calls:
+                    # A model-authored artifact draft is never committed directly.
+                    # Give it one bounded synthesis pass under the final-document
+                    # contract before runtime-owned export.
+                    if _pdf_requested and not force_synthesis and current_iteration < max_iterations:
+                        messages.append({
+                            "role": "user",
+                            "content": synthesis_instruction(
+                                original_user_query,
+                                image_context=image_context_provided,
+                                is_detailed=is_detailed_mode,
+                                pdf_already_generated=False,
+                            ),
+                        })
+                        force_synthesis = True
+                        continue
+
                     is_reasoning_leak = _looks_like_internal_reasoning(raw_content)
                     is_placeholder = (
                         raw_content.strip() in ("Processing your request...", "I'll help you with that.", "")
@@ -822,6 +1140,7 @@ async def run_elixposearch_pipeline(user_query: str, user_image: str, event_id: 
                     user_query=_dr_query, user_image=user_image,
                     event_id=event_id, session_id=session_id, emit_event=emit_event,
                     ledger_request_id=ledger_request_id,
+                    request_intent=original_user_query,
                 ):
                     yield event
                 return
@@ -1210,6 +1529,7 @@ async def run_elixposearch_pipeline(user_query: str, user_image: str, event_id: 
             return
 
     except Exception as e:
+        task_failed = True
         logger.error(f"Pipeline error: {e}", exc_info=True)
         _error_msg = (
             "Oops — something unexpected went wrong on my end. "
@@ -1224,6 +1544,21 @@ async def run_elixposearch_pipeline(user_query: str, user_image: str, event_id: 
     finally:
         # Skip all persistence for ephemeral sessions — nothing to save
         if not is_ephemeral:
+            if session_context and memoized_results.get("active_task") and not memoized_results.get("clarification_blocked") and not memoized_results.get("task_terminal"):
+                try:
+                    terminal_status = TaskStatus.FAILED if task_failed else TaskStatus.COMPLETED
+                    terminal_task = task_with_status(
+                        memoized_results["active_task"],
+                        terminal_status,
+                    )
+                    await asyncio.to_thread(
+                        session_context.ledger.set_task_state,
+                        active_task=terminal_task,
+                        pending_clarification=None,
+                    )
+                    memoized_results["active_task"] = terminal_task
+                except Exception as exc:
+                    logger.warning(f"[Pipeline] Failed to finalize task state: {exc}")
             if session_id and "session_context" in memoized_results and memoized_results["session_context"]:
                 try:
                     ctx = memoized_results["session_context"]

--- a/lixsearch/pipeline/optimized_tool_execution.py
+++ b/lixsearch/pipeline/optimized_tool_execution.py
@@ -18,6 +18,7 @@ from pipeline.config import MAX_IMAGES_TO_INCLUDE, LOG_MESSAGE_QUERY_TRUNCATE, L
 from pipeline.formalOptimization import ConstrainedOptimizer
 from commons.robustnessFramework import ToolOutputSanitizer, SanitizationPolicy
 from urllib.parse import urlparse
+from sessions.clarification import artifacts_blocked
 
 
 def _display_url(url: str, max_len: int = 40) -> str:
@@ -35,6 +36,10 @@ def _display_url(url: str, max_len: int = 40) -> str:
 
 async def optimized_tool_execution(function_name: str, function_args: dict, memoized_results: dict, emit_event_func):
     try:
+        if artifacts_blocked(memoized_results):
+            logger.warning(f"[Pipeline] Blocked tool while clarification is pending: {function_name}")
+            yield "[BLOCKED] Required clarification is still pending; no tool was executed."
+            return
         VALID_TOOL_NAMES = {tool["function"]["name"] for tool in tools}
         if function_name not in VALID_TOOL_NAMES:
             error_msg = f"Tool '{function_name}' is not available. Valid tools are: {', '.join(sorted(VALID_TOOL_NAMES))}"

--- a/lixsearch/pipeline/response_builder.py
+++ b/lixsearch/pipeline/response_builder.py
@@ -7,6 +7,7 @@ from loguru import logger
 
 from pipeline.config import POLLINATIONS_ENDPOINT, LLM_MODEL, LOG_MESSAGE_PREVIEW_TRUNCATE
 from pipeline.helpers import _scrub_tool_names, sanitize_final_response
+from sessions.clarification import artifacts_blocked
 from pipeline.utils import format_sse
 
 MODEL = LLM_MODEL
@@ -151,7 +152,7 @@ async def auto_generate_pdf(final_content, query_lower, memoized_results, event_
     _already_has_pdf = bool(memoized_results.get("generated_pdfs"))
     if _already_has_pdf or memoized_results.get("pdf_export_attempted"):
         return None
-    if memoized_results.get("suppress_pdf_export"):
+    if memoized_results.get("suppress_pdf_export") or artifacts_blocked(memoized_results):
         return None
     if not any(kw in query_lower.lower() for kw in ("pdf", "export", "save as", "document")):
         return None

--- a/lixsearch/sessions/clarification.py
+++ b/lixsearch/sessions/clarification.py
@@ -1,0 +1,314 @@
+"""Deterministic task and clarification state transitions.
+
+Models classify language; this module validates their structured output and
+owns every state transition.  Tool code never decides whether a clarification
+has been satisfied.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+import json
+import re
+import time
+from typing import Any, Dict, Iterable, Optional
+
+
+class TaskStatus(str, Enum):
+    ACTIVE = "active"
+    AWAITING_CLARIFICATION = "awaiting_clarification"
+    READY_TO_EXECUTE = "ready_to_execute"
+    COMPLETED = "completed"
+    FAILED = "failed"
+
+
+class ResolutionAction(str, Enum):
+    RESOLVE = "resolve"
+    PARTIAL = "partial"
+    UNRELATED = "unrelated"
+    CANCEL = "cancel"
+    REPLACE = "replace"
+
+
+@dataclass(frozen=True)
+class ClarificationNeed:
+    required: bool = False
+    missing_fields: tuple[str, ...] = ()
+    question: str = ""
+
+
+@dataclass(frozen=True)
+class ClarificationResolution:
+    action: ResolutionAction
+    values: Dict[str, str]
+    defaulted_fields: tuple[str, ...] = ()
+    question: str = ""
+    replacement_request: str = ""
+
+
+def _extract_json(text: str) -> Dict[str, Any]:
+    value = (text or "").strip()
+    value = re.sub(r"^```(?:json)?\s*|\s*```$", "", value, flags=re.I)
+    try:
+        parsed = json.loads(value)
+    except (TypeError, ValueError):
+        match = re.search(r"\{.*\}", value, re.DOTALL)
+        if not match:
+            return {}
+        try:
+            parsed = json.loads(match.group(0))
+        except ValueError:
+            return {}
+    return parsed if isinstance(parsed, dict) else {}
+
+
+def _clean_fields(fields: Iterable[Any]) -> tuple[str, ...]:
+    cleaned = []
+    for field in fields or ():
+        name = re.sub(r"[^a-z0-9_.-]+", "_", str(field).strip().lower()).strip("_")
+        if name and name not in cleaned:
+            cleaned.append(name[:64])
+    return tuple(cleaned[:8])
+
+
+_BLOCKING_FIELD_KINDS = frozenset({
+    "identity",
+    "user_owned",
+    "credential",
+    "authorization",
+    "irreversible",
+    "required_scope",
+})
+_DEFAULTABLE_FIELD_KINDS = frozenset({"preference", "output_metadata"})
+_ALL_FIELD_KINDS = _BLOCKING_FIELD_KINDS | _DEFAULTABLE_FIELD_KINDS
+
+
+def _typed_clarification_fields(raw: Dict[str, Any]):
+    """Normalize the flat wire contract; retain nested support for stored tests."""
+    if "fields" not in raw:
+        blocking_raw = raw.get("blocking_fields")
+        defaultable_raw = raw.get("defaultable_fields")
+        questions = raw.get("questions")
+        if not isinstance(blocking_raw, list) or not isinstance(defaultable_raw, list):
+            return None
+        if not isinstance(questions, dict):
+            return None
+        blocking = _clean_fields(blocking_raw)
+        defaultable = _clean_fields(defaultable_raw)
+        if len(blocking) != len(blocking_raw) or len(defaultable) != len(defaultable_raw):
+            return None
+        if set(blocking) & set(defaultable):
+            return None
+        parsed = []
+        for name in blocking:
+            question = str(questions.get(name) or "").strip()[:300]
+            if not question:
+                return None
+            parsed.append((name, "required_scope", question))
+        parsed.extend((name, "preference", "") for name in defaultable)
+        return parsed
+
+    entries = raw.get("fields")
+    if not isinstance(entries, list):
+        return None
+    parsed = []
+    for entry in entries[:8]:
+        if not isinstance(entry, dict):
+            return None
+        names = _clean_fields((entry.get("name"),))
+        kind = str(entry.get("kind") or "").strip().lower()
+        question = str(entry.get("question") or "").strip()[:300]
+        if not names or kind not in _ALL_FIELD_KINDS:
+            return None
+        if kind in _BLOCKING_FIELD_KINDS and not question:
+            return None
+        parsed.append((names[0], kind, question))
+    return parsed
+
+
+def parse_clarification_need(router_output: str) -> ClarificationNeed:
+    data = _extract_json(router_output)
+    raw = data.get("clarification") or {}
+    if not isinstance(raw, dict) or raw.get("required") is not True:
+        return ClarificationNeed()
+    declared = _typed_clarification_fields(raw)
+    if declared is None:
+        return ClarificationNeed()
+    blocking = [(name, question) for name, kind, question in declared if kind in _BLOCKING_FIELD_KINDS]
+    if not blocking:
+        return ClarificationNeed()
+    fields = tuple(name for name, _ in blocking)
+    if len(blocking) == 1:
+        question = blocking[0][1]
+    else:
+        labels = ", ".join(name.replace("_", " ") for name, _ in blocking)
+        question = f"Please provide the required information for: {labels}."
+    return ClarificationNeed(required=True, missing_fields=fields, question=question[:500])
+
+
+def has_decision_contract(router_output: str) -> bool:
+    data = _extract_json(router_output)
+    if str(data.get("mode", "")).upper() not in {"DIRECT", "TOOLS"}:
+        return False
+    if str(data.get("context", "")).upper() not in {"STANDALONE", "CONTINUATION"}:
+        return False
+    raw = data.get("clarification")
+    if not isinstance(raw, dict) or not isinstance(raw.get("required"), bool):
+        return False
+    declared = _typed_clarification_fields(raw)
+    if declared is None:
+        return False
+    has_blocking = any(kind in _BLOCKING_FIELD_KINDS for _, kind, _ in declared)
+    return raw["required"] is has_blocking
+
+
+def has_resolution_contract(resolver_output: str) -> bool:
+    data = _extract_json(resolver_output)
+    return str(data.get("action", "")).lower() in {action.value for action in ResolutionAction}
+
+
+def parse_resolution(resolver_output: str) -> ClarificationResolution:
+    data = _extract_json(resolver_output)
+    try:
+        action = ResolutionAction(str(data.get("action", "unrelated")).lower())
+    except ValueError:
+        action = ResolutionAction.UNRELATED
+    raw_values = data.get("values") or {}
+    if not isinstance(raw_values, dict):
+        raw_values = {}
+    values = {}
+    for key, value in raw_values.items():
+        names = _clean_fields((key,))
+        if names and str(value).strip():
+            values[names[0]] = str(value).strip()[:1000]
+    return ClarificationResolution(
+        action=action,
+        values=values,
+        defaulted_fields=_clean_fields(data.get("defaulted_fields") or []),
+        question=str(data.get("question") or "").strip()[:500],
+        replacement_request=str(data.get("replacement_request") or "").strip()[:4000],
+    )
+
+
+def create_pending_task(
+    original_request: str,
+    missing_fields: Iterable[str],
+    question: str,
+    *,
+    source_turn: int,
+    request_id: str,
+    routing: Optional[Dict[str, str]] = None,
+) -> tuple[Dict[str, Any], Dict[str, Any]]:
+    fields = _clean_fields(missing_fields)
+    if not fields or not question.strip():
+        raise ValueError("pending clarification requires fields and a question")
+    now = time.time()
+    active = {
+        "status": TaskStatus.AWAITING_CLARIFICATION.value,
+        "original_request": original_request.strip(),
+        "source_turn": int(source_turn),
+        "request_id": request_id,
+        "required_fields": list(fields),
+        "resolved_fields": {},
+        "routing": dict(routing or {}),
+        "updated_at": now,
+    }
+    pending = {
+        "missing_fields": list(fields),
+        "question": question.strip()[:500],
+        "source_turn": int(source_turn),
+        "request_id": request_id,
+        "updated_at": now,
+    }
+    return active, pending
+
+
+def apply_resolution(
+    active_task: Dict[str, Any],
+    pending: Dict[str, Any],
+    resolution: ClarificationResolution,
+) -> tuple[Dict[str, Any], Optional[Dict[str, Any]], Optional[str]]:
+    """Validate and apply one resolver result.
+
+    Returns ``(active_task, pending_state, executable_request)``.  A non-None
+    executable request is the only transition that may proceed to tools.
+    """
+    active = dict(active_task or {})
+    waiting = dict(pending or {})
+    now = time.time()
+
+    if resolution.action == ResolutionAction.CANCEL:
+        active.update(status=TaskStatus.COMPLETED.value, outcome="cancelled", updated_at=now)
+        return active, None, None
+
+    if resolution.action == ResolutionAction.REPLACE and resolution.replacement_request:
+        return {}, None, resolution.replacement_request
+
+    required = _clean_fields(waiting.get("missing_fields") or active.get("required_fields") or [])
+    resolved = dict(active.get("resolved_fields") or {})
+    defaulted = set(active.get("defaulted_fields") or [])
+    if resolution.action in {ResolutionAction.RESOLVE, ResolutionAction.PARTIAL}:
+        supplied = dict(resolution.values)
+        if len(required) == 1 and len(supplied) == 1 and required[0] not in supplied:
+            supplied = {required[0]: next(iter(supplied.values()))}
+        for field in required:
+            value = supplied.get(field)
+            if value:
+                resolved[field] = value
+        defaulted.update(field for field in resolution.defaulted_fields if field in required)
+    remaining = tuple(
+        field for field in required if not resolved.get(field) and field not in defaulted
+    )
+
+    if resolution.action == ResolutionAction.RESOLVE and not remaining:
+        original = str(active.get("original_request") or "").strip()
+        if not original:
+            return active, waiting, None
+        details = [f"{field}: {resolved[field]}" for field in required if field in resolved]
+        details.extend(f"{field}: use a context-appropriate default" for field in required if field in defaulted)
+        detail_text = "; ".join(details)
+        executable = f"{original}\n\nClarified requirements: {detail_text}"
+        active.update(
+            status=TaskStatus.READY_TO_EXECUTE.value,
+            resolved_fields=resolved,
+            defaulted_fields=sorted(defaulted),
+            resolved_request=executable,
+            updated_at=now,
+        )
+        return active, None, executable
+
+    active.update(
+        status=TaskStatus.AWAITING_CLARIFICATION.value,
+        resolved_fields=resolved,
+        defaulted_fields=sorted(defaulted),
+        updated_at=now,
+    )
+    waiting["missing_fields"] = list(remaining or required)
+    if resolution.question:
+        waiting["question"] = resolution.question
+    waiting["updated_at"] = now
+    return active, waiting, None
+
+
+def task_with_status(task: Optional[Dict[str, Any]], status: TaskStatus, **updates) -> Dict[str, Any]:
+    value = dict(task or {})
+    value.update(updates)
+    value["status"] = status.value
+    value["updated_at"] = time.time()
+    return value
+
+
+def artifacts_blocked(memoized_results: Dict[str, Any]) -> bool:
+    task = memoized_results.get("active_task") or {}
+    return bool(
+        memoized_results.get("pending_clarification")
+        or task.get("status") == TaskStatus.AWAITING_CLARIFICATION.value
+    )
+
+
+def pending_for_request(snapshot, session_id: Optional[str], is_ephemeral: bool):
+    """Return pending state only when this request carries its owning session."""
+    if not session_id or is_ephemeral or snapshot is None:
+        return None
+    return snapshot.pending_clarification

--- a/nginx.conf
+++ b/nginx.conf
@@ -17,13 +17,13 @@ http {
   resolver 127.0.0.11 valid=10s;
   resolver_timeout 5s;
 
-  log_format main '$remote_addr - $remote_user [$time_local] "$request" '
-                  '$status $body_bytes_sent "$http_referer" '
+  log_format main '$remote_addr - $remote_user [$time_local] "$request_method $uri $server_protocol" '
+                  '$status $body_bytes_sent '
                   '"$http_user_agent" "$http_x_forwarded_for"';
 
-  log_format detailed '$remote_addr - $remote_user [$time_local] "$request" '
+  log_format detailed '$remote_addr - $remote_user [$time_local] "$request_method $uri $server_protocol" '
                       '$status $body_bytes_sent '
-                      '"$http_x_session_id" "$http_x_request_id" '
+                      '"$http_x_request_id" '
                       '$request_time $upstream_response_time '
                       '"$http_user_agent"';
 

--- a/skills/export-documents/SKILL.md
+++ b/skills/export-documents/SKILL.md
@@ -25,6 +25,7 @@ Export completed content without repeating research.
 - A successful export must return its stable download URL; after success, stop exporting.
 - Do not invent citations or expand source content.
 - Do not export without explicit user intent.
+- Never export a clarification question or any task whose required fields remain unresolved. Pending clarification is a hard runtime block, not a suggestion.
 - Preserve the text response if export fails.
 
 ## Runtime contract

--- a/skills/orchestrate-search/SKILL.md
+++ b/skills/orchestrate-search/SKILL.md
@@ -9,12 +9,13 @@ Build a bounded execution graph. Prefer deterministic routing over an extra mode
 
 ## Route
 
-1. Classify the request without executing tools.
-2. Select only necessary skills: `research-web`, `handle-media`, `recall-memory`, `export-documents`, and `synthesize-answer`.
-3. Run independent skills concurrently.
-4. Preserve dependencies: search → fetch → synthesize → export. Export is a single terminal step after the answer is finalized.
-5. Stream progress as tasks begin and results arrive.
-6. Cancel optional work once sufficient evidence exists.
+1. Resolve any same-session pending clarification before general routing. Validate every indispensable field; explicitly mark safely defaultable fields instead of repeatedly asking for them, and never invent user-supplied values.
+2. Classify the request without executing tools.
+3. Select only necessary skills: `research-web`, `handle-media`, `recall-memory`, `export-documents`, and `synthesize-answer`.
+4. Run independent skills concurrently.
+5. Preserve dependencies: search → fetch → synthesize → export. Export is a single terminal step after the answer is finalized.
+6. Stream progress as tasks begin and results arrive.
+7. Cancel optional work once sufficient evidence exists.
 
 ## Routing rules
 
@@ -22,6 +23,8 @@ Build a bounded execution graph. Prefer deterministic routing over an extra mode
 - Do not ask for optional preferences when a safe, reversible default exists. State the assumption briefly when it matters.
 - Resolve references from supplied message history or session context. If neither contains the referenced item, say what is missing and ask the user to restate or attach it; never invent the missing context.
 - A clarification can continue only through the same `session_id`, a `previous_response_id`, or client-supplied message history. Treat an otherwise context-free request as standalone.
+- While required fields remain unresolved, call no tools and create no artifacts. Persist the exact missing fields, source turn, and one concise question.
+- Treat cancellation, task replacement, unrelated replies, partial answers, and complete answers as distinct transitions. Clear pending state only after validated completion, explicit cancellation, or explicit replacement.
 - Answer stable, self-contained questions directly.
 - Use web research for information likely to have changed.
 - Use deep research only for genuinely multi-part investigations.

--- a/tester/test_clarification_state_machine.py
+++ b/tester/test_clarification_state_machine.py
@@ -1,0 +1,451 @@
+import asyncio
+import importlib
+
+from pipeline.optimized_tool_execution import optimized_tool_execution
+from pipeline.response_builder import auto_generate_pdf
+from sessions.clarification import (
+    ClarificationResolution,
+    ClarificationNeed,
+    ResolutionAction,
+    TaskStatus,
+    apply_resolution,
+    artifacts_blocked,
+    create_pending_task,
+    has_decision_contract,
+    has_resolution_contract,
+    parse_clarification_need,
+    parse_resolution,
+    pending_for_request,
+)
+from sessions.ledger import SessionSnapshot
+
+
+def make_task(fields=("comparison_subjects",)):
+    return create_pending_task(
+        "Compare options in the Indian market and make a PDF",
+        fields,
+        "Which options should I compare?",
+        source_turn=7,
+        request_id="request-7",
+    )
+
+
+def test_router_parses_exact_missing_comparison_subjects():
+    need = parse_clarification_need(
+        "{\"mode\":\"TOOLS\",\"context\":\"STANDALONE\",\"clarification\":"
+        "{\"required\":true,\"fields\":["
+        "{\"name\":\"comparison subjects\",\"kind\":\"identity\","
+        "\"question\":\"Which three products should I compare?\"}]} }"
+    )
+    assert need.required is True
+    assert need.missing_fields == ("comparison_subjects",)
+    assert need.question == "Which three products should I compare?"
+
+
+def test_router_records_ambiguous_referent_as_an_exact_missing_field():
+    need = parse_clarification_need(
+        "{\"mode\":\"DIRECT\",\"context\":\"CONTINUATION\",\"clarification\":"
+        "{\"required\":true,\"fields\":["
+        "{\"name\":\"referenced content\",\"kind\":\"user_owned\","
+        "\"question\":\"What should I turn into a PDF?\"}]} }"
+    )
+    assert need.required is True
+    assert need.missing_fields == ("referenced_content",)
+
+
+def test_incomplete_or_malformed_router_output_fails_open_without_fake_state():
+    assert parse_clarification_need("not json").required is False
+    assert parse_clarification_need(
+        '{"clarification":{"required":true,"missing_fields":[],"question":"What?"}}'
+    ).required is False
+
+
+def test_pending_task_preserves_original_routing_for_post_resolution_execution():
+    active, pending = create_pending_task(
+        "Original task",
+        ("required_subject",),
+        "Which subject?",
+        source_turn=3,
+        request_id="request-3",
+        routing={"mode": "tools", "context": "standalone"},
+    )
+    assert active["routing"] == {"mode": "tools", "context": "standalone"}
+    next_task, next_pending, executable = apply_resolution(
+        active,
+        pending,
+        ClarificationResolution(
+            ResolutionAction.RESOLVE,
+            {"required_subject": "the supplied subject"},
+        ),
+    )
+    assert next_pending is None
+    assert executable
+    assert next_task["routing"]["mode"] == "tools"
+
+
+def test_complete_reply_fills_fields_and_preserves_original_request():
+    active, pending = make_task()
+    resolution = ClarificationResolution(
+        ResolutionAction.RESOLVE,
+        {"comparison_subjects": "A, B, and C"},
+    )
+    next_task, next_pending, executable = apply_resolution(active, pending, resolution)
+
+    assert next_pending is None
+    assert next_task["status"] == TaskStatus.READY_TO_EXECUTE.value
+    assert next_task["source_turn"] == 7
+    assert "Compare options in the Indian market" in executable
+    assert "comparison_subjects: A, B, and C" in executable
+
+
+def test_single_validated_value_maps_to_the_only_pending_field_generically():
+    active, pending = make_task(("required_entity_set",))
+    resolution = ClarificationResolution(
+        ResolutionAction.RESOLVE,
+        {"entities": "first, second, and third"},
+    )
+    next_task, next_pending, executable = apply_resolution(active, pending, resolution)
+    assert next_pending is None
+    assert next_task["resolved_fields"] == {
+        "required_entity_set": "first, second, and third"
+    }
+    assert "required_entity_set: first, second, and third" in executable
+
+
+def test_resolution_contract_rejects_malformed_or_unscoped_actions():
+    assert has_resolution_contract('{"action":"resolve","values":{}}') is True
+    assert has_resolution_contract('{"action":"execute","values":{}}') is False
+    assert has_resolution_contract("not-json") is False
+
+
+def test_partial_reply_keeps_only_unresolved_fields_pending():
+    active, pending = make_task(("first_subject", "second_subject"))
+    resolution = ClarificationResolution(
+        ResolutionAction.PARTIAL,
+        {"first_subject": "A"},
+        question="What is the second subject?",
+    )
+    next_task, next_pending, executable = apply_resolution(active, pending, resolution)
+
+    assert executable is None
+    assert next_task["resolved_fields"] == {"first_subject": "A"}
+    assert next_pending["missing_fields"] == ["second_subject"]
+
+
+def test_unrelated_reply_cannot_silently_complete_even_with_values():
+    active, pending = make_task()
+    resolution = ClarificationResolution(
+        ResolutionAction.UNRELATED,
+        {"comparison_subjects": "should not be accepted"},
+        question="Which options should I compare?",
+    )
+    next_task, next_pending, executable = apply_resolution(active, pending, resolution)
+
+    assert executable is None
+    assert next_task["resolved_fields"] == {}
+    assert next_pending["missing_fields"] == ["comparison_subjects"]
+
+
+def test_cancellation_clears_pending_without_execution():
+    active, pending = make_task()
+    next_task, next_pending, executable = apply_resolution(
+        active, pending, ClarificationResolution(ResolutionAction.CANCEL, {})
+    )
+    assert executable is None
+    assert next_pending is None
+    assert next_task["status"] == TaskStatus.COMPLETED.value
+    assert next_task["outcome"] == "cancelled"
+
+
+def test_replacement_clears_old_task_and_routes_new_request():
+    active, pending = make_task()
+    next_task, next_pending, executable = apply_resolution(
+        active,
+        pending,
+        ClarificationResolution(
+            ResolutionAction.REPLACE,
+            {},
+            replacement_request="Summarize today's technology news",
+        ),
+    )
+    assert next_task == {}
+    assert next_pending is None
+    assert executable == "Summarize today's technology news"
+
+
+def test_pending_state_requires_its_same_non_ephemeral_session_carrier():
+    _, pending = make_task()
+    snapshot = SessionSnapshot([], pending_clarification=pending)
+    assert pending_for_request(snapshot, "conv_owner", False) == pending
+    assert pending_for_request(snapshot, None, False) is None
+    assert pending_for_request(snapshot, "conv_owner", True) is None
+
+
+def test_artifacts_and_all_tools_are_blocked_while_waiting():
+    active, pending = make_task()
+    memo = {"active_task": active, "pending_clarification": pending}
+    assert artifacts_blocked(memo) is True
+
+    async def exercise():
+        pdf = await auto_generate_pdf("x" * 200, "make a pdf", memo, "event")
+        chunks = []
+        async for chunk in optimized_tool_execution(
+            "web_search", {"query": "x"}, memo, lambda *_: None
+        ):
+            chunks.append(chunk)
+        return pdf, chunks
+
+    pdf, chunks = asyncio.run(exercise())
+    assert pdf is None
+    assert chunks == ["[BLOCKED] Required clarification is still pending; no tool was executed."]
+
+
+def test_resolution_parser_defaults_to_unrelated_on_invalid_output():
+    assert parse_resolution("garbage").action == ResolutionAction.UNRELATED
+
+
+def test_pipeline_clarification_returns_before_tools_without_session(monkeypatch):
+    pipeline = importlib.import_module("pipeline.lixsearch")
+
+    async def classify(*args, **kwargs):
+        return (
+            "tools",
+            "standalone",
+            ClarificationNeed(True, ("subjects",), "Which subjects should I compare?"),
+        )
+
+    monkeypatch.setattr(pipeline, "_decide_request_mode", classify)
+
+    async def exercise():
+        return [
+            chunk
+            async for chunk in pipeline.run_elixposearch_pipeline(
+                "Compare these and make a PDF",
+                None,
+                event_id="clarify-no-session",
+                is_ephemeral=True,
+            )
+        ]
+
+    output = "".join(asyncio.run(exercise()))
+    assert "Which subjects should I compare?" in output
+    assert "Download PDF" not in output
+
+
+def test_same_session_unrelated_reply_keeps_pending_state(monkeypatch):
+    pipeline = importlib.import_module("pipeline.lixsearch")
+    active, pending = make_task()
+
+    class FakeLedger:
+        def __init__(self):
+            self.states = []
+
+        def acquire_lock(self):
+            return "owned"
+
+        def release_lock(self, token):
+            return token == "owned"
+
+        def load_snapshot(self):
+            return SessionSnapshot([], active, pending, 7)
+
+        def set_task_state(self, **state):
+            self.states.append(state)
+
+    fake_ledger = FakeLedger()
+
+    class FakeContext:
+        def __init__(self, session_id):
+            self.ledger = fake_ledger
+
+        def add_message(self, *args, **kwargs):
+            return 8
+
+    async def resolve(*args, **kwargs):
+        return ClarificationResolution(
+            ResolutionAction.UNRELATED,
+            {},
+            question="Which options should I compare?",
+        )
+
+    monkeypatch.setattr(pipeline, "LedgerSessionContext", FakeContext)
+    monkeypatch.setattr(pipeline, "_resolve_pending_clarification", resolve)
+
+    async def exercise():
+        return [
+            chunk
+            async for chunk in pipeline.run_elixposearch_pipeline(
+                "How is the weather?",
+                None,
+                event_id="unrelated-reply",
+                session_id="conv_owner",
+            )
+        ]
+
+    output = "".join(asyncio.run(exercise()))
+    assert "Which options should I compare?" in output
+    assert fake_ledger.states[-1]["pending_clarification"]["missing_fields"] == ["comparison_subjects"]
+
+
+def test_router_failure_creates_safe_generic_pending_state(monkeypatch):
+    pipeline = importlib.import_module("pipeline.lixsearch")
+
+    def unavailable(*args, **kwargs):
+        raise TimeoutError("router timeout")
+
+    monkeypatch.setattr(pipeline, "LLM_DECISION_MODEL", "router-a")
+    monkeypatch.setattr(pipeline, "LLM_MODEL_FALLBACK", "router-b")
+    monkeypatch.setattr(pipeline.requests, "post", unavailable)
+    mode, context, need = asyncio.run(
+        pipeline._decide_request_mode("a complete-looking request", 0, {})
+    )
+    assert mode == "tools"
+    assert context == "standalone"
+    assert need.required is True
+    assert need.missing_fields == ("request_details",)
+    assert need.question == "What specific subject or inputs should I use for this request?"
+
+
+def test_generic_admission_fallback_resolves_next_turn_without_router(monkeypatch):
+    pipeline = importlib.import_module("pipeline.lixsearch")
+
+    def unavailable(*args, **kwargs):
+        raise TimeoutError("resolver timeout")
+
+    monkeypatch.setattr(pipeline, "LLM_DECISION_MODEL", "router-a")
+    monkeypatch.setattr(pipeline, "LLM_MODEL_FALLBACK", "router-b")
+    monkeypatch.setattr(pipeline.requests, "post", unavailable)
+    resolution = asyncio.run(
+        pipeline._resolve_pending_clarification(
+            {"original_request": "Complete the requested task"},
+            {"missing_fields": ["request_details"]},
+            "Use the three supplied database systems",
+            {},
+        )
+    )
+    assert resolution.action == ResolutionAction.RESOLVE
+    assert resolution.values == {
+        "request_details": "Use the three supplied database systems"
+    }
+
+
+def test_router_uses_first_valid_redundant_contract(monkeypatch):
+    pipeline = importlib.import_module("pipeline.lixsearch")
+
+    class Response:
+        def raise_for_status(self):
+            return None
+
+        def json(self):
+            return {
+                "choices": [{
+                    "message": {
+                        "content": (
+                            "{\"mode\":\"TOOLS\",\"context\":\"STANDALONE\","
+                            "\"clarification\":{\"required\":true,\"fields\":["
+                            "{\"name\":\"required_subject\",\"kind\":\"identity\","
+                            "\"question\":\"Which subject?\"}]} }"
+                        )
+                    }
+                }]
+            }
+
+    def route(_url, json, **_kwargs):
+        if json["model"] == "router-a":
+            raise TimeoutError("primary unavailable")
+        return Response()
+
+    monkeypatch.setattr(pipeline, "LLM_DECISION_MODEL", "router-a")
+    monkeypatch.setattr(pipeline, "LLM_MODEL_FALLBACK", "router-b")
+    monkeypatch.setattr(pipeline.requests, "post", route)
+
+    mode, context, need = asyncio.run(
+        pipeline._decide_request_mode("an incomplete request", 0, {})
+    )
+    assert (mode, context) == ("tools", "standalone")
+    assert need.missing_fields == ("required_subject",)
+
+
+def test_safe_default_can_complete_any_generic_pending_contract():
+    active, pending = create_pending_task(
+        "Evaluate the supplied candidates and create the requested artifact",
+        ("candidate_identities", "evaluation_preferences"),
+        "Which candidates and preferences should be used?",
+        source_turn=11,
+        request_id="request-11",
+    )
+    resolution = ClarificationResolution(
+        ResolutionAction.RESOLVE,
+        {"candidate_identities": "candidate A and candidate B"},
+        defaulted_fields=("evaluation_preferences",),
+    )
+
+    next_task, next_pending, executable = apply_resolution(active, pending, resolution)
+
+    assert next_pending is None
+    assert next_task["status"] == TaskStatus.READY_TO_EXECUTE.value
+    assert next_task["defaulted_fields"] == ["evaluation_preferences"]
+    assert "candidate_identities: candidate A and candidate B" in executable
+    assert "evaluation_preferences: use a context-appropriate default" in executable
+
+
+def test_resolution_parser_accepts_only_named_defaulted_fields():
+    resolution = parse_resolution(
+        "{\"action\":\"resolve\",\"values\":{},"
+        "\"defaulted_fields\":[\"Presentation Preferences\",\"***\"]}"
+    )
+    assert resolution.defaulted_fields == ("presentation_preferences",)
+
+
+def test_unrelated_reply_cannot_default_pending_fields():
+    active, pending = make_task(("required_subject",))
+    resolution = ClarificationResolution(
+        ResolutionAction.UNRELATED,
+        {},
+        defaulted_fields=("required_subject",),
+        question="Which subject?",
+    )
+
+    next_task, next_pending, executable = apply_resolution(active, pending, resolution)
+
+    assert executable is None
+    assert next_task["defaulted_fields"] == []
+    assert next_pending["missing_fields"] == ["required_subject"]
+
+
+def test_decision_contract_requires_complete_structured_state():
+    valid = (
+        "{\"mode\":\"DIRECT\",\"context\":\"STANDALONE\","
+        "\"clarification\":{\"required\":false,\"fields\":[]}}"
+    )
+    assert has_decision_contract(valid) is True
+    assert has_decision_contract("Use tools and continue") is False
+    assert has_decision_contract(
+        "{\"mode\":\"TOOLS\",\"context\":\"STANDALONE\","
+        "\"clarification\":{\"required\":true}}"
+    ) is False
+
+
+def test_typed_admission_discards_defaultable_output_metadata():
+    decision = (
+        "{\"mode\":\"TOOLS\",\"context\":\"STANDALONE\",\"clarification\":"
+        "{\"required\":true,\"blocking_fields\":[\"candidate_identities\"],"
+        "\"defaultable_fields\":[\"artifact_title\"],"
+        "\"questions\":{\"candidate_identities\":"
+        "\"Which candidates should be evaluated?\"}}}"
+    )
+
+    assert has_decision_contract(decision) is True
+    need = parse_clarification_need(decision)
+    assert need.required is True
+    assert need.missing_fields == ("candidate_identities",)
+    assert need.question == "Which candidates should be evaluated?"
+
+
+def test_typed_admission_cannot_mark_only_defaultable_fields_as_required():
+    inconsistent = (
+        "{\"mode\":\"TOOLS\",\"context\":\"STANDALONE\",\"clarification\":"
+        "{\"required\":true,\"blocking_fields\":[],"
+        "\"defaultable_fields\":[\"presentation_style\"],\"questions\":{}}}"
+    )
+    assert has_decision_contract(inconsistent) is False

--- a/tester/test_output_commit_harness.py
+++ b/tester/test_output_commit_harness.py
@@ -1,0 +1,30 @@
+from pipeline.helpers import StreamingTagFilter
+from pipeline.lixsearch import _may_stream_uncommitted_output
+
+
+def test_reasoning_tags_split_across_chunks_never_reach_sse_text():
+    filter_ = StreamingTagFilter()
+    chunks = ["<thi", "nking>private plan", "</think", "ing>Final answer"]
+    visible = "".join(filter_.feed(chunk) for chunk in chunks) + filter_.flush()
+    assert visible == "Final answer"
+
+
+def test_unclosed_reasoning_block_is_discarded_on_flush():
+    filter_ = StreamingTagFilter()
+    visible = filter_.feed("<analysis>private plan") + filter_.flush()
+    assert visible == ""
+
+
+def test_artifact_draft_is_buffered_until_commit():
+    assert _may_stream_uncommitted_output(
+        "event-id", has_tools=False, artifact_requested=True
+    ) is False
+
+
+def test_plain_final_answer_can_stream_after_tool_boundary_is_clear():
+    assert _may_stream_uncommitted_output(
+        "event-id", has_tools=False, artifact_requested=False
+    ) is True
+    assert _may_stream_uncommitted_output(
+        "event-id", has_tools=True, artifact_requested=False
+    ) is False

--- a/tester/test_pdf_research_pipeline.py
+++ b/tester/test_pdf_research_pipeline.py
@@ -158,3 +158,95 @@ def test_explicit_tomorrow_shifts_generic_local_anchor():
     query = "make a three day itinerary starting tomorrow"
     assert missing_local_date_anchor(query, "## September 2nd 2026", info) == "2026-09-03"
     assert missing_local_date_anchor(query, "## September 3rd 2026", info) is None
+
+
+def test_deep_research_completes_requested_artifact_before_done():
+    import pipeline.deep_search as deep_search
+
+    research_query = "Compare the candidate storage engines"
+    original_request = "Research the candidate storage engines and provide a PDF"
+    pdf_url = "https://search.elixpo.com/generated/storage-engines.pdf"
+
+    async def run():
+        with (
+            mock.patch.object(
+                deep_search,
+                "_decompose_query_with_llm",
+                new=mock.AsyncMock(return_value=["orbital materials"]),
+            ),
+            mock.patch.object(
+                deep_search,
+                "_execute_deep_search_sub_query",
+                new=mock.AsyncMock(
+                    return_value=(
+                        "# Findings\n\n" + "Grounded evidence. " * 12,
+                        ["https://example.test/evidence"],
+                        [],
+                    )
+                ),
+            ),
+            mock.patch.object(
+                deep_search,
+                "auto_generate_pdf",
+                new=mock.AsyncMock(return_value=pdf_url),
+            ) as generate,
+        ):
+            chunks = [
+                chunk
+                async for chunk in deep_search._run_deep_search_pipeline(
+                    user_query=research_query,
+                    user_image=None,
+                    event_id="deep-artifact",
+                    session_id=None,
+                    emit_event=lambda _kind, content: content,
+                    request_intent=original_request,
+                )
+            ]
+            generate.assert_awaited_once()
+            assert generate.await_args.args[1] == original_request
+            return chunks
+
+    chunks = asyncio.run(run())
+    output = "".join(chunks)
+    assert pdf_url in output
+    assert output.index("PDF ready for download") < output.index("<TASK>DONE</TASK>")
+
+
+def test_deep_research_rejects_source_free_output_before_stream_or_export():
+    import pipeline.deep_search as deep_search
+
+    async def run():
+        with (
+            mock.patch.object(
+                deep_search,
+                "_decompose_query_with_llm",
+                new=mock.AsyncMock(return_value=["unverified thread"]),
+            ),
+            mock.patch.object(
+                deep_search,
+                "_execute_deep_search_sub_query",
+                new=mock.AsyncMock(return_value=("Confident but unsupported answer", [], [])),
+            ),
+            mock.patch.object(
+                deep_search,
+                "auto_generate_pdf",
+                new=mock.AsyncMock(),
+            ) as generate,
+        ):
+            chunks = [
+                chunk
+                async for chunk in deep_search._run_deep_search_pipeline(
+                    user_query="Research a subject and provide a PDF",
+                    user_image=None,
+                    event_id="deep-no-evidence",
+                    session_id=None,
+                    emit_event=lambda _kind, content: content,
+                )
+            ]
+            generate.assert_not_awaited()
+            return chunks
+
+    output = "".join(asyncio.run(run()))
+    assert "Confident but unsupported answer" not in output
+    assert "enough verifiable sources" in output
+    assert output.endswith("<TASK>DONE</TASK>")

--- a/tester/test_request_log_redaction.py
+++ b/tester/test_request_log_redaction.py
@@ -1,0 +1,34 @@
+from starlette.requests import Request
+
+from commons.requestID import _request_log_target
+
+
+def test_request_logs_never_include_query_values():
+    request = Request({
+        "type": "http",
+        "http_version": "1.1",
+        "method": "GET",
+        "scheme": "https",
+        "path": "/api/search",
+        "raw_path": b"/api/search",
+        "query_string": b"query=private+prompt&key=secret-token&session_id=private-session",
+        "headers": [],
+        "client": ("127.0.0.1", 1234),
+        "server": ("search.elixpo.com", 443),
+    })
+
+    target = _request_log_target(request)
+    assert target == "/api/search"
+    assert "secret-token" not in target
+    assert "private+prompt" not in target
+    assert "private-session" not in target
+
+
+def test_nginx_access_logs_exclude_query_referrer_and_session_values():
+    config = open("nginx.conf", encoding="utf-8").read()
+    log_section = config.split("access_log /var/log/nginx/access.log main;", 1)[0]
+    assert '"$request"' not in log_section
+    assert "$request_uri" not in log_section
+    assert "$http_referer" not in log_section
+    assert "$http_x_session_id" not in log_section
+    assert "$request_method $uri $server_protocol" in log_section


### PR DESCRIPTION
Closes #46

## What changed
- adds deterministic task states: active, awaiting_clarification, ready_to_execute, completed, and failed
- stores exact missing fields, source turn, original request, resolved fields, and pending question in the Redis session ledger
- resolves pending replies before general routing
- distinguishes complete, partial, unrelated, cancellation, and replacement transitions
- reconstructs the executable request from the original request plus validated field values
- hard-blocks every tool and PDF auto-export while required fields remain pending
- prevents ephemeral/sessionless requests from consuming durable pending state
- aligns orchestration and document-export skill contracts with runtime enforcement

The model performs bounded structured language classification; state validation and transitions are deterministic.

## Verification
- 73 broad offline regression tests passed
- 13 focused clarification tests passed
- covers missing comparison subjects, ambiguous referents, partial answers, unrelated replies, cancellation, replacement, artifact blocking, session isolation, and pipeline early-return behavior

No deployment performed.